### PR TITLE
 fix: revert custom code override for maven publishing

### DIFF
--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -3,37 +3,37 @@
 # You can run this workflow by navigating to https://www.github.com/OneBusAway/kotlin-sdk/actions/workflows/publish-sonatype.yml
 name: Publish Sonatype
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
-    release:
-        types: [published]
+  release:
+    types: [published]
 
 jobs:
-    publish:
-        name: publish
-        runs-on: ubuntu-latest
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Set up Java
-              uses: actions/setup-java@v3
-              with:
-                  distribution: temurin
-                  java-version: |
-                      8
-                      17
-                  cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: |
+            8
+            17
+          cache: gradle
 
-            - name: Set up Gradle
-              uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
 
-            - name: Publish to Sonatype
-              run: |
-                  ./gradlew --parallel --no-daemon publish
-              env:
-                  SONATYPE_USERNAME: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}
-                  SONATYPE_PASSWORD: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_PASSWORD || secrets.SONATYPE_PASSWORD }}
-                  GPG_SIGNING_KEY_ID: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_GPG_SIGNING_KEY_ID || secrets.GPG_SIGNING_KEY_ID }}
-                  GPG_SIGNING_KEY: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_GPG_SIGNING_KEY || secrets.GPG_SIGNING_KEY }}
-                  GPG_SIGNING_PASSWORD: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_GPG_SIGNING_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
+      - name: Publish to Sonatype
+        run: |
+          ./gradlew publishAndReleaseToMavenCentral --stacktrace -PmavenCentralUsername="$SONATYPE_USERNAME" -PmavenCentralPassword="$SONATYPE_PASSWORD"
+        env:
+          SONATYPE_USERNAME: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_PASSWORD || secrets.SONATYPE_PASSWORD }}
+          GPG_SIGNING_KEY_ID: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_GPG_SIGNING_KEY_ID || secrets.GPG_SIGNING_KEY_ID }}
+          GPG_SIGNING_KEY: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_GPG_SIGNING_KEY || secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.ONEBUSAWAY_SDK_SONATYPE_GPG_SIGNING_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}


### PR DESCRIPTION
Hola 👋, 

I am an eng working at stainless-sdks. I have noticed that your kotlin-sdk's Maven publishing workflow has been failing.

It turns out that due to this [custom code commit](https://github.com/OneBusAway/kotlin-sdk/commit/c340889775d44d9ec58982ec02b471016eef419d) that changed the file indentation levels, the custom code system have been overriding the lines touched.

So when when you toggled over from the legacy Sonatype OSSRH release flow to their newer Sonatype Central release flow, [the changes](https://github.com/OneBusAway/kotlin-sdk/blob/generated/.github/workflows/publish-sonatype.yml) actually never materialized in the `next` and `main` branches.

This pull request rectifies that situation by porting over the ci manifest changes required to successfully release to the Sonatype Central.

The change set is identical to the difference [between `generated` and `main`](https://github.com/OneBusAway/kotlin-sdk/compare/main..generated#.github/workflows/publish-sonatype.yml) on `publish-sonatype.yml`.

---

Coincidentally, since ~ 3 days ago ( v0.1.0-alpha.7 ), the JavaSDK has been experiencing a [token error](https://github.com/OneBusAway/java-sdk/actions/runs/11469118014/job/31915673478).

> Upload failed: {"error":{"message":"Invalid token"}} 

I do not believe that this is related to this particular custom code issue, since [v0.1.0-alpha.6](https://github.com/OneBusAway/java-sdk/actions/runs/11180553916) was able to be published [without code changes](https://github.com/OneBusAway/java-sdk/compare/v0.1.0-alpha.7..v0.1.0-alpha.6) to the publishing flows.

Since I do not have access to your Sonatype account, you might have to look into that 👍 , I suspect that a token rotation via https://central.sonatype.com/ should suffice.





