### PR TITLE
fix: revert to sonatype portal release flow

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,12 +1,16 @@
 plugins {
     `kotlin-dsl`
+    kotlin("jvm") version "1.9.22"
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 repositories {
     gradlePluginPortal()
+    mavenCentral()
 }
 
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
+    implementation("com.vanniktech:gradle-maven-publish-plugin:0.28.0")
 }

--- a/buildSrc/src/main/kotlin/onebusaway-sdk.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/onebusaway-sdk.java.gradle.kts
@@ -1,6 +1,9 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import java.util.Locale
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     `java-library`
@@ -9,11 +12,6 @@ plugins {
 
 repositories {
     mavenCentral()
-}
-
-configure<JavaPluginExtension> {
-    withJavadocJar()
-    withSourcesJar()
 }
 
 configure<SpotlessExtension> {
@@ -34,10 +32,6 @@ java {
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Werror")
     options.release.set(8)
-}
-
-tasks.named<Jar>("javadocJar") {
-    setZip64(true)
 }
 
 tasks.named<Jar>("jar") {

--- a/buildSrc/src/main/kotlin/onebusaway-sdk.kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/onebusaway-sdk.kotlin.gradle.kts
@@ -1,5 +1,6 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.vanniktech.maven.publish.*
 
 plugins {
     id("onebusaway-sdk.java")

--- a/buildSrc/src/main/kotlin/onebusaway-sdk.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/onebusaway-sdk.publish.gradle.kts
@@ -3,65 +3,52 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.get
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    `maven-publish`
-    `signing`
+    id("com.vanniktech.maven.publish")
 }
 
-configure<PublishingExtension> {
-    publications {
-        register<MavenPublication>("maven") {
-            from(components["java"])
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
 
-            pom {
-                name.set("OneBusAway")
-                description.set("The OneBusAway REST API. For use with servers like\nhttps://api.pugetsound.onebusaway.org")
-                url.set("https://developer.onebusaway.org")
+extra["signingInMemoryKey"] = System.getenv("GPG_SIGNING_KEY")
+extra["signingInMemoryKeyId"] = System.getenv("GPG_SIGNING_KEY_ID")
+extra["signingInMemoryKeyPassword"] = System.getenv("GPG_SIGNING_PASSWORD")
 
-                licenses {
-                    license {
-                        name.set("Apache-2.0")
-                    }
-                }
+configure<MavenPublishBaseExtension> {
+    signAllPublications()
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
-                developers {
-                    developer {
-                        name.set("Onebusaway SDK")
-                        email.set("info@onebusaway.org")
-                    }
-                }
+    this.coordinates(project.group.toString(), project.name, project.version.toString())
 
-                scm {
-                    connection.set("scm:git:git://github.com/OneBusAway/kotlin-sdk.git")
-                    developerConnection.set("scm:git:git://github.com/OneBusAway/kotlin-sdk.git")
-                    url.set("https://github.com/OneBusAway/kotlin-sdk")
-                }
+    pom {
+        name.set("OneBusAway")
+        description.set("The OneBusAway REST API. For use with servers like\nhttps://api.pugetsound.onebusaway.org")
+        url.set("https://developer.onebusaway.org")
 
-                versionMapping {
-                    allVariants {
-                        fromResolutionResult()
-                    }
-                }
+        licenses {
+            license {
+                name.set("Apache-2.0")
             }
         }
-    }
-}
 
-signing {
-    val signingKeyId = System.getenv("GPG_SIGNING_KEY_ID")?.ifBlank { null }
-    val signingKey = System.getenv("GPG_SIGNING_KEY")?.ifBlank { null }
-    val signingPassword = System.getenv("GPG_SIGNING_PASSWORD")?.ifBlank { null }
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(
-            signingKeyId,
-            signingKey,
-            signingPassword,
-        )
-        sign(publishing.publications["maven"])
-    }
-}
+        developers {
+            developer {
+                name.set("Onebusaway SDK")
+                email.set("info@onebusaway.org")
+            }
+        }
 
-tasks.named("publish") {
-    dependsOn(":closeAndReleaseSonatypeStagingRepository")
+        scm {
+            connection.set("scm:git:git://github.com/OneBusAway/kotlin-sdk.git")
+            developerConnection.set("scm:git:git://github.com/OneBusAway/kotlin-sdk.git")
+            url.set("https://github.com/OneBusAway/kotlin-sdk")
+        }
+    }
 }


### PR DESCRIPTION
Greetings @Ahmedhossamdev:

It seems like there had been a mistake somewhere, possibly due to picking the wrong side of a merge conflict such that the current sonatype release flow had been set to legacy OSSRH instead of the correct portal flow.

This PR rectified that mistake and fixes the release flow.

Best regards,

Hao

---

You can see the entire diff here: https://gist.github.com/stainless-bot/8dd83690fcf89be498bce3b026d4617e